### PR TITLE
📄 27: Added simpler menu macro

### DIFF
--- a/app/templates/menu.html
+++ b/app/templates/menu.html
@@ -1,0 +1,40 @@
+{% macro menu() -%}
+  <link type="text/css" rel="stylesheet" href="../static/styles/menu.css">
+
+  <div class="menu-wrapper">
+    <!-- Welcome Page -->
+    <a class="menu-button" href="/welcome">
+      <img src="../static/icons/home.svg" />
+    </a>
+
+    <!-- About Me Page -->
+    <a class="menu-button" href="/about">
+      <img src="../static/icons/about.svg" />
+    </a>
+
+    <!-- Projects Page -->
+    <a class="menu-button" href="/projects">
+      <img src="../static/icons/book.svg" />
+    </a>
+
+    <!-- Experience Page -->
+    <a class="menu-button" href="/experience">
+      <img src="../static/icons/flag.svg" />
+    </a>
+
+    <!-- Travel Page -->
+    <a class="menu-button" href="/travel">
+      <img src="../static/icons/location.svg" />
+    </a>
+
+    <!-- Linkedin -->
+    <a class="menu-button" href="https://linkedin.com" target="_blank">
+      <img src="../static/icons/linkedin.svg" />
+    </a>
+
+    <!-- Github -->
+    <a class="menu-button" href="https://github.com" target="_blank">
+      <img src="../static/icons/github.svg" />
+    </a>
+  </div>
+{%- endmacro %}

--- a/app/templates/travel.html
+++ b/app/templates/travel.html
@@ -6,7 +6,6 @@
     <meta property="og:title" content="Personal Portfolio">
     <meta property="og:description" content="My Personal Portfolio">
     <link type="text/css" rel="stylesheet" href="../static/styles/travel.css">
-    <link type="text/css" rel="stylesheet" href="../static/styles/menu.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>
     <link href="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css" rel="stylesheet" />
     <script src="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js"></script>
@@ -17,29 +16,8 @@
   <body>
     <div class="noise-wrapper"></div>
     <div class="wrapper">
-      <div class="menu-wrapper">
-        <a class="menu-button" href="/welcome">
-          <img src="../static/icons/home.svg" />
-        </a>
-        <a class="menu-button" href="/about">
-          <img src="../static/icons/about.svg" />
-        </a>
-        <a class="menu-button" href="/">
-          <img src="../static/icons/book.svg" />
-        </a>
-        <a class="menu-button" href="/">
-          <img src="../static/icons/flag.svg" />
-        </a>
-        <a class="menu-button" href="/travel">
-          <img src="../static/icons/location.svg" />
-        </a>
-        <a class="menu-button" href="https://linkedin.com" target="_blank">
-          <img src="../static/icons/linkedin.svg" />
-        </a>
-        <a class="menu-button" href="https://github.com" target="_blank">
-          <img src="../static/icons/github.svg" />
-        </a>
-      </div>
+      {% import 'menu.html' as menu %}
+      {{ menu.menu() }}
 
       <h1 id="title">Around the Globe</h1>
 

--- a/app/templates/welcome.html
+++ b/app/templates/welcome.html
@@ -6,7 +6,6 @@
     <meta property="og:title" content="Personal Portfolio">
     <meta property="og:description" content="My Personal Portfolio">
     <link type="text/css" rel="stylesheet" href="../static/styles/welcome.css">
-    <link type="text/css" rel="stylesheet" href="../static/styles/menu.css">
     <script src="../static/scripts/welcome.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>
     <title>Welcome</title>
@@ -14,29 +13,8 @@
   <body>
     <div class="noise-wrapper"></div>
     <div class="wrapper">
-      <div class="menu-wrapper">
-        <a class="menu-button" href="/welcome">
-          <img src="../static/icons/home.svg" />
-        </a>
-        <a class="menu-button" href="/about">
-          <img src="../static/icons/about.svg" />
-        </a>
-        <a class="menu-button" href="/">
-          <img src="../static/icons/book.svg" />
-        </a>
-        <a class="menu-button" href="/">
-          <img src="../static/icons/flag.svg" />
-        </a>
-        <a class="menu-button" href="/travel">
-          <img src="../static/icons/location.svg" />
-        </a>
-        <a class="menu-button" href="https://linkedin.com" target="_blank">
-          <img src="../static/icons/linkedin.svg" />
-        </a>
-        <a class="menu-button" href="https://github.com" target="_blank">
-          <img src="../static/icons/github.svg" />
-        </a>
-      </div>
+      {% import 'menu.html' as menu %}
+      {{ menu.menu() }}
 
       <div class="main-information-wrapper">
         <div class="welcome-text">


### PR DESCRIPTION
#27 I made a simple menu macro that allows us to use the same menu on all of the pages, so this means we only need to modify 1 file instead of all of them.

I made this change in the Welcome and Travel pages, I didn't want to change it on the rest to prevent any collisions with other branches..

Here are some steps to use the macro:

1. In the page you're adding the macro delete the 'menu.css'
2. Replace the following code
```html
<div class="menu-wrapper">
  <a class="menu-button" href="/welcome">
    <img src="../static/icons/home.svg" />
  </a>
  <a class="menu-button" href="/about">
    <img src="../static/icons/about.svg" />
  </a>
  <a class="menu-button" href="/">
    <img src="../static/icons/book.svg" />
  </a>
  <a class="menu-button" href="/">
    <img src="../static/icons/flag.svg" />
  </a>
  <a class="menu-button" href="/">
    <img src="../static/icons/location.svg" />
  </a>
  <a class="menu-button" href="https://linkedin.com" target="_blank">
    <img src="../static/icons/linkedin.svg" />
  </a>
  <a class="menu-button" href="https://github.com" target="_blank">
    <img src="../static/icons/github.svg" />
  </a>
</div>
``` 

For this code:
```html
{% import 'menu.html' as menu %}
{{ menu.menu() }}
``` 